### PR TITLE
[MRK-3106]set max_receive_message_length

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -2,7 +2,7 @@ import { V2Client, V2PromiseClient } from './proto/clarifai/api/service_grpc_web
 
 export class ClarifaiStub {
   static grpc (hostname = 'api.clarifai.com') {
-    const options = {'grpc.max_receive_message_length': 128 *1024 * 1024} // 128 MB
+    const options = { 'grpc.max_receive_message_length': 128 * 1024 * 1024 } // 128 MB
     return new V2Client(hostname, null, options)
   }
 }


### PR DESCRIPTION
Set the grpc channel max receive message length to 128MB.