### PR TITLE
Automate package publishing (again)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
           tag_name: "v%s"
           tag_message: "v%s"
           create_tag: "true"
-          commit_pattern: "^Release (\\S+)"
+          commit_pattern: "^GRPC clients version (\\S+)"
           publish_command: "yarn"
           publish_args: "--non-interactive"
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,13 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches:
+      - master
+    tags:
+      - '**'
   pull_request:
-    branches: [ master ]
+    branches:
+      - master
 
 jobs:
   build:
@@ -23,7 +27,7 @@ jobs:
         run: yarn build
 
   release:
-    if: ${{ github.event_name != 'pull_request' }}
+    if: github.ref_type == 'tag'
     needs: build
     runs-on: ubuntu-20.04
     steps:
@@ -37,12 +41,8 @@ jobs:
       - name: Publish to NPM
         uses: pascalgn/npm-publish-action@1.3.9
         with:
-          tag_name: "v%s"
-          tag_message: "v%s"
-          create_tag: "true"
+          create_tag: "false"
           commit_pattern: "^GRPC clients version (\\S+)"
-          publish_command: "yarn"
-          publish_args: "--non-interactive"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -45,4 +45,4 @@ client.postApps(req, auth, (err, resp) => {
 
 Publishing the client to NPM involves merging a PR with 2 things:
 1. Updates the `version` field in `package.json` to the appropriate version.
-2. Commit message should begin with `"Release"` eg `"Release 9.4.0"`.
+2. Commit message should begin with `"GRPC clients version"` eg `"GRPC clients version 9.4.0"`.


### PR DESCRIPTION
Previously, ci.yml's `release` job was checking for something like `Release 1.2.0` but the commit message being used by the main repo's automation has a different format. This PR updates it to match.