### PR TITLE
Fix URL in ClarifaiStub to point to our grpc-web proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,32 +17,34 @@ import { ClarifaiStub } from "clarifai-web-grpc";
 import { App } from "clarifai-web-grpc/proto/clarifai/api/resources_pb";
 import { PostAppsRequest } from "clarifai-web-grpc/proto/clarifai/api/service_pb";
 
-const client = ClarifaiStub.grpc();
-// use client to create an App
+// get a client object
+const client = ClarifaiStub.promise()
 
+// create an app
 const app = new App();
 app.setId("cat-app");
 app.setDefaultWorkflowId("General-Detection");
 app.setDescription("An app for some cats");
 
+// create a request
 const req = new PostAppsRequest();
 req.setAppsList([app]);
 
+// send the request
 const auth = {
-  "X-Clarifai-Session-Token": "MY-CLARIFAI-PERSONAL-ACCESS-TOKEN",
+  "authorization": `Key ${process.env.CLARIFAI_TOKEN}`,
 };
+const resp = await client.postApps(req, auth);
 
-client.postApps(req, auth, (err, resp) => {
-  if (err) {
-    console.error(err);
-  } else {
-    console.log(resp.getAppsList()[0].getId()); // logs "cat-app"
-  }
-});
+// log the app id
+console.log(resp.getAppsList()[0].getId());
 ```
 
-## Publishing to NPM
+## Examples
 
+See the examples directory for more examples of how to use the clarifai API client
+
+## Publishing to NPM
 Publishing the client to NPM involves merging a PR with 2 things:
 1. Updates the `version` field in `package.json` to the appropriate version.
 2. Commit message should begin with `"GRPC clients version"` eg `"GRPC clients version 9.4.0"`.

--- a/examples/post-app.ts
+++ b/examples/post-app.ts
@@ -1,6 +1,6 @@
 import { ClarifaiStub } from '../index'
-import { App } from '../proto/clarifai/api/resources_pb'
-import { PostAppsRequest } from '../proto/clarifai/api/service_pb'
+import { App } from '../resources'
+import { PostAppsRequest } from '../service'
 
 export async function createAnApp() {
   // get a client object
@@ -8,9 +8,9 @@ export async function createAnApp() {
 
   // create an app
   const app = new App();
-  app.setId("cat-app");
-  app.setDefaultWorkflowId("General-Detection");
-  app.setDescription("An app for some cats");
+  app.setId('cat-app');
+  app.setDefaultWorkflowId('General-Detection');
+  app.setDescription('An app for some cats');
 
   // create a request
   const req = new PostAppsRequest();
@@ -18,7 +18,7 @@ export async function createAnApp() {
 
   // send the request
   const auth = {
-    "authorization": `Key ${process.env.CLARIFAI_TOKEN}`,
+    authorization: `Key ${process.env.CLARIFAI_TOKEN}`,
   };
   const resp = await client.postApps(req, auth);
 

--- a/examples/post-app.ts
+++ b/examples/post-app.ts
@@ -1,0 +1,27 @@
+import { ClarifaiStub } from '../index'
+import { App } from '../proto/clarifai/api/resources_pb'
+import { PostAppsRequest } from '../proto/clarifai/api/service_pb'
+
+export async function createAnApp() {
+  // get a client object
+  const client = ClarifaiStub.promise()
+
+  // create an app
+  const app = new App();
+  app.setId("cat-app");
+  app.setDefaultWorkflowId("General-Detection");
+  app.setDescription("An app for some cats");
+
+  // create a request
+  const req = new PostAppsRequest();
+  req.setAppsList([app]);
+
+  // send the request
+  const auth = {
+    "authorization": `Key ${process.env.CLARIFAI_TOKEN}`,
+  };
+  const resp = await client.postApps(req, auth);
+
+  // log the app id
+  console.log(resp.getAppsList()[0].getId());
+}

--- a/examples/post-input.ts
+++ b/examples/post-input.ts
@@ -1,0 +1,43 @@
+import { Struct } from 'google-protobuf/google/protobuf/struct_pb';
+import { ClarifaiStub } from '../index'
+import { Data, Input, Text } from '../proto/clarifai/api/resources_pb'
+import { PostInputsRequest } from '../proto/clarifai/api/service_pb'
+
+export async function createAnInput() {
+  // create an input with some text. In a real app, this might come
+  // from a filepicker widget, or maybe a datasource like S3 or a database.
+  const input = new Input();
+
+  const data = new Data();
+
+  const text = new Text();
+  text.setRaw("hello world");
+
+  // we can also attach metadata to an input so we can correlate it with
+  // other data in our system. This can be any JSON-serializable object.
+  const metadata = Struct.fromJavaScript({
+    product_id: '1234',
+    location: 'San Francisco',
+    client: 'acme',
+  });
+
+  data.setMetadata(metadata);
+
+  input.setData(data);
+
+  // get a client object
+  const client = ClarifaiStub.promise()
+
+  // create a request
+  const req = new PostInputsRequest();
+  req.setInputsList([input]);
+
+  // send the request
+  const auth = {
+    "authorization": `Key ${process.env.CLARIFAI_TOKEN}`,
+  };
+  const resp = await client.postInputs(req, auth);
+
+  // log the input id
+  console.log(resp.getInputsList()[0].getId());
+}

--- a/examples/post-input.ts
+++ b/examples/post-input.ts
@@ -1,7 +1,6 @@
-import { Struct } from 'google-protobuf/google/protobuf/struct_pb';
 import { ClarifaiStub } from '../index'
-import { Data, Input, Text } from '../proto/clarifai/api/resources_pb'
-import { PostInputsRequest } from '../proto/clarifai/api/service_pb'
+import { Struct, Data, Input, Text } from '../resources'
+import { PostInputsRequest } from '../service'
 
 export async function createAnInput() {
   // create an input with some text. In a real app, this might come
@@ -34,7 +33,7 @@ export async function createAnInput() {
 
   // send the request
   const auth = {
-    "authorization": `Key ${process.env.CLARIFAI_TOKEN}`,
+    authorization: `Key ${process.env.CLARIFAI_TOKEN}`,
   };
   const resp = await client.postInputs(req, auth);
 

--- a/index.ts
+++ b/index.ts
@@ -1,12 +1,17 @@
 import { V2Client, V2PromiseClient } from './proto/clarifai/api/service_grpc_web_pb'
 
 export class ClarifaiStub {
-  static grpc (hostname = 'api.clarifai.com') {
+  static grpc (hostname = 'https://api-grpc-web.clarifai.com') {
     const options = { 'grpc.max_receive_message_length': 128 * 1024 * 1024 } // 128 MB
     return new V2Client(hostname, null, options)
+  }
+
+  static promise (hostname = 'https://api-grpc-web.clarifai.com') {
+    const options = { 'grpc.max_receive_message_length': 128 * 1024 * 1024 } // 128 MB
+    return new V2PromiseClient(hostname, null, options)
   }
 }
 
 export { V2Client, V2PromiseClient }
-export { RpcError, Metadata, ClientReadableStream } from 'grpc-web'
+export { RpcError, Metadata, ClientReadableStream, Request, UnaryResponse } from 'grpc-web'
 export { BaseResponse } from './proto/clarifai/api/status/status_pb'

--- a/resources.ts
+++ b/resources.ts
@@ -1,1 +1,2 @@
 export * from './proto/clarifai/api/resources_pb'
+export { Struct } from 'google-protobuf/google/protobuf/struct_pb'


### PR DESCRIPTION
This PR fixes a few small things:

1. Updates the default URL in the `grpc()` stub method to point to our grpc-web proxy.
2. Adds a new `promise()` stub method to construct a `V2PromiseClient` with the same configuration as the callback client.
3. Added a new `examples` dir with a couple of short code snippets for users to bootstrap their usage of the client.
4. Update README a bit.